### PR TITLE
Fix protocol (show up as SAS, not Parallel SCSI)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: objective-c
+xcode_project: raid/SASMegaRAID.xcodeproj
+xcode_scheme: SASMegaRAID

--- a/raid/README.mkd
+++ b/raid/README.mkd
@@ -1,6 +1,6 @@
 I/O Kit driver for LSI MegaRAID SAS family of hardware RAID controllers, which isn't supported by proprietary MegaRAID.kext (PPC) and AppleLSIFusionMPT.kext or AppleRAIDCard.kext (x86). This driver is Xcode project, for OS X.
 
-This family of controllers uses SCSI protocol for data passing, so your device will be presented as parallel SCSI controller to the system.
+~~This family of controllers uses SCSI protocol for data passing, so your device will be presented as parallel SCSI controller to the system.~~
 
 Here's rough list of cards which should be supported:
 - LSI MegaRAID SAS 8xxx, 92xx

--- a/raid/SASMegaRAID/SASMegaRAID-Info.plist
+++ b/raid/SASMegaRAID/SASMegaRAID-Info.plist
@@ -45,6 +45,13 @@
 			<string>0x04111000 0x04131000 0x00601000 0x007c1000 0x00151028 0x00601028 0x00781000 0x00791000 0x00731000</string>
 			<key>IOPCIMatchComment</key>
 			<string>Symbios Logic MegaRAID SAS 1064R, MegaRAID Verde ZCR, SAS1078, SAS1078DE; Dell PERC 5, PERC 6; Symbios Logic MegaRAID SAS2108 CRYPTO GEN2, MegaRAID SAS2108 GEN2, MegaRAID SAS2008</string>
+			<key>Protocol Characteristics</key>
+			<dict>
+				<key>Physical Interconnect</key>
+				<string>SAS</string>
+				<key>Physical Interconnect Location</key>
+				<string>External</string>
+			</dict>
 		</dict>
 	</dict>
 	<key>OSBundleLibraries</key>

--- a/raid/SASMegaRAID/SASMegaRAID.cpp
+++ b/raid/SASMegaRAID/SASMegaRAID.cpp
@@ -541,7 +541,8 @@ mraid_mem *SASMegaRAID::AllocMem(vm_size_t size)
         return NULL;
     
     /* Hardware requirement: Page size aligned */
-    if (!(mm->bmd = IOBufferMemoryDescriptor::inTaskWithOptions(kernel_task, kIOMemoryPhysicallyContiguous, size, PAGE_SIZE))) {
+    if (!(mm->bmd = IOBufferMemoryDescriptor::inTaskWithPhysicalMask
+          (kernel_task, kIOMemoryPhysicallyContiguous, size, addr_mask & ~PAGE_MASK))) {
         goto free;
     }
     mm->bmd->prepare();

--- a/raid/bring-mfiutil.sh
+++ b/raid/bring-mfiutil.sh
@@ -21,9 +21,9 @@ svn co svn://svn.freebsd.org/base/release/9.1.0/sys/sys ${TMP}/sys
 svn co svn://svn.freebsd.org/base/release/9.1.0/sys/dev/mfi ${TMP}/mfi
 svn co svn://svn.freebsd.org/base/release/9.1.0/sys/cam/scsi ${TMP}/scsi
 [ ! -e ${TMP}/${LU}.tgz ] && \
-	curl http://www.opensource.apple.com/tarballs/libutil/${LU}.tar.gz -o ${TMP}/${LU}.tgz
+	curl -L https://opensource.apple.com/tarballs/libutil/${LU}.tar.gz -o ${TMP}/${LU}.tgz
 [ ! -e ${TMP}/${XNU}.tgz ] && \
-	curl http://www.opensource.apple.com/tarballs/xnu/${XNU}.tar.gz -o ${TMP}/${XNU}.tgz
+	curl -L https://opensource.apple.com/tarballs/xnu/${XNU}.tar.gz -o ${TMP}/${XNU}.tgz
 
 cd ./mfiutil
 tar xzf ${TMP}/${LU}.tgz -C .


### PR DESCRIPTION
This simple fix makes the controller to show up as SAS in System Profiler instead of Parallel SCSI.